### PR TITLE
feat(variable about): variable are now loaded into db as one to many

### DIFF
--- a/server/internal/controllers/about.go
+++ b/server/internal/controllers/about.go
@@ -20,7 +20,10 @@ func getServiceFromType(serviceType string, service models.Service) models.Servi
 	var actions []models.Action
 	var reactions []models.Reaction
 	for _, event := range service.Events {
-		pkg.DB.Preload("Parameters").Find(&event)
+		if err := pkg.DB.Preload("Parameters").Preload("Variables").Find(&event).Error; err != nil {
+			log.Error().Err(err).Msg("Failed to preload event data")
+			continue
+		}
 		var parameters []models.Parameter
 		for _, param := range event.Parameters {
 			parameters = append(parameters, models.Parameter{
@@ -35,6 +38,8 @@ func getServiceFromType(serviceType string, service models.Service) models.Servi
 				Id:          event.ID,
 				Name:        event.Name,
 				Description: event.Description,
+				ShortName:   event.ShortName,
+				Variables:   event.Variables.GetVariables(),
 				Parameters:  parameters,
 			})
 		} else if serviceType == "reaction" {

--- a/server/internal/models/about.go
+++ b/server/internal/models/about.go
@@ -10,6 +10,8 @@ type Action struct {
 	Id          uint        `json:"id"`
 	Name        string      `json:"name"`
 	Description string      `json:"description"`
+	ShortName   string      `json:"shortname"`
+	Variables   []string    `json:"variables"`
 	Parameters  []Parameter `json:"parameters"`
 }
 

--- a/server/internal/models/event.go
+++ b/server/internal/models/event.go
@@ -1,22 +1,56 @@
 package models
 
-import "gorm.io/gorm"
+import (
+    "errors"
+    "github.com/goccy/go-json"
+    "gorm.io/gorm"
+)
 
 type WorkflowStatus string
 
+type Variables struct {
+    gorm.Model
+    Value   string `json:"value"`
+    EventID uint   `gorm:"foreignKey:EventID" json:"event_id"`
+}
+
+type VariablesList []Variables
+
+func (v *VariablesList) UnmarshalJSON(data []byte) error {
+    var arr []string
+    if err := json.Unmarshal(data, &arr); err == nil {
+        var result []Variables
+        for _, s := range arr {
+            result = append(result, Variables{Value: s})
+        }
+        *v = result
+        return nil
+    }
+    return errors.New("invalid format for variables (expected an array of strings)")
+}
+
+func (v VariablesList) GetVariables() []string {
+    var values []string
+    for _, variable := range v {
+        values = append(values, variable.Value)
+    }
+    return values
+}
+
 type Event struct {
-	gorm.Model
-        ShortName       string          `json:"short_name"`
-	Name            string          `json:"name"`
-	Description     string          `json:"description"`
-	ServiceID       uint            `gorm:"foreignKey:ServiceID" json:"service_id"`
-	Parameters      []Parameters    `json:"parameters"`
-	Type            EventType       `gorm:"type:enum('action', 'reaction');not null" json:"type"`
-	WorkflowEvents  []WorkflowEvent `gorm:"constraint:OnDelete:CASCADE;" json:"workflow_events"`
+    gorm.Model
+    ShortName      string          `json:"short_name"`
+    Name           string          `json:"name"`
+    Description    string          `json:"description"`
+    ServiceID      uint            `gorm:"foreignKey:ServiceID" json:"service_id"`
+    Variables      VariablesList   `gorm:"constraint:OnDelete:CASCADE;" json:"variables"`
+    Parameters     []Parameters    `json:"parameters"`
+    Type           EventType       `gorm:"type:enum('action', 'reaction');not null" json:"type"`
+    WorkflowEvents []WorkflowEvent `gorm:"constraint:OnDelete:CASCADE;" json:"workflow_events"`
 }
 
 const (
-	WorkflowStatusPending   WorkflowStatus = "pending"
-	WorkflowStatusProcessed WorkflowStatus = "processed"
-	WorkflowStatusFailed    WorkflowStatus = "failed"
+    WorkflowStatusPending   WorkflowStatus = "pending"
+    WorkflowStatusProcessed WorkflowStatus = "processed"
+    WorkflowStatusFailed    WorkflowStatus = "failed"
 )

--- a/server/internal/pkg/about.go
+++ b/server/internal/pkg/about.go
@@ -69,7 +69,6 @@ func updateService(newService *models.Service, existingService *models.Service) 
 
 func processEvent(newEvent models.Event, serviceID uint) error {
 	var existingEvent models.Event
-
 	err := DB.Where("name = ? AND service_id = ?", newEvent.Name, serviceID).First(&existingEvent).Error
 	if err == nil {
 		return updateEvent(newEvent, &existingEvent)

--- a/server/internal/pkg/db.go
+++ b/server/internal/pkg/db.go
@@ -18,6 +18,7 @@ func migrateDB() error {
 		&models.Workflow{},
 		&models.Service{},
 		&models.Event{},
+		&models.Variables{},
 		&models.Parameters{},
 		&models.Token{},
 		&models.WorkflowEvent{},

--- a/server/services/microsoft.json
+++ b/server/services/microsoft.json
@@ -2,9 +2,11 @@
   "name": "microsoft",
   "events": [
     {
+      "short_name": "email_received_ms",
       "name": "New Email Received",
       "description": "Triggered when a new email is received in your mailbox.",
       "type": "action",
+      "variables": ["sender", "subject", "body"],
       "parameters": []
     },
     {
@@ -19,8 +21,14 @@
       "type": "action",
       "parameters": [
         {
-          "name": "channel_id",
-          "description": "ID of the Teams channel.",
+          "name": "team_name",
+          "description": "Name of the teams.",
+          "type": "string",
+          "is_required": false
+        },
+        {
+          "name": "channel_name",
+          "description": "Name of the Teams channel.",
           "type": "string"
         }
       ]
@@ -31,8 +39,8 @@
       "type": "action",
       "parameters": [
         {
-          "name": "team_id",
-          "description": "ID of the Teams team.",
+          "name": "team_name",
+          "description": "Name of the teams.",
           "type": "string"
         }
       ]
@@ -55,25 +63,20 @@
       "type": "action",
       "parameters": [
         {
-          "name": "file_id",
-          "description": "ID of the updated file.",
+          "name": "folder_path",
+          "description": "Path of the folder where the file is updated.",
           "type": "string"
         }
       ]
     },
     {
-      "name": "File deleted",
-      "description": "Triggered when a file is deleted from OneDrive.",
+      "name": "Event has started",
+      "description": "Triggered when an event has started in your calendar.",
       "type": "action",
-      "parameters": [
-        {
-          "name": "file_id",
-          "description": "ID of the deleted file.",
-          "type": "string"
-        }
-      ]
+      "parameters": []
     },
     {
+      "short_name": "email_send_ms",
       "name": "Send an Email",
       "description": "Send an email from your mailbox.",
       "type": "reaction",
@@ -118,8 +121,13 @@
       "type": "reaction",
       "parameters": [
         {
-          "name": "channel_id",
-          "description": "ID of the Teams channel.",
+          "name": "team_name",
+          "description": "Name of the teams.",
+          "type": "string"
+        },
+        {
+          "name": "channel_name",
+          "description": "Name of the Teams channel.",
           "type": "string"
         },
         {


### PR DESCRIPTION
#### **Summary of Changes**
- Added `GetVariables()` method to the `Variables` model to convert `VariablesList` into a `[]string` for JSON responses.
- Preloaded `Variables` in the database query within `getServiceFromType`.
- Updated `Action` responses to include `variables` as a list of strings using `GetVariables()`.

#### **Benefits**
- Simplifies the API response format for `variables` while maintaining the one-to-many relationship in the database.
- Ensures `variables` are dynamically loaded and transformed before returning the response.

#### **Testing**
- Validate JSON outputs for events with variables, no variables, and edge cases.
- Confirm database queries correctly preload `Variables`.

#### **Example Output**
```json
"variables": ["sender", "subject", "body"]
``` 
